### PR TITLE
Raise opensearch to 2.19.1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-def opensearch_version = '2.19.0'
+def opensearch_version = '2.19.1'
 
 pipeline {
   agent any


### PR DESCRIPTION
This will eliminate the last open vulnerabilities for Axon Ivy Engine 13.1 and 12.0.